### PR TITLE
Fix highlighting the whole row

### DIFF
--- a/src/components/LogLines.js
+++ b/src/components/LogLines.js
@@ -142,7 +142,7 @@ export default function LogLines(props) {
                     height={500}
                     itemCount={lineCount}
                     itemSize={20}
-                    style={{overflow: "scroll", width:"100%"}}
+                    style={{overflow: "scroll"}}
                     ref={listRef}
                 >
                     {Line}

--- a/src/components/LogLines.js
+++ b/src/components/LogLines.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, {useEffect, useState} from "react";
 import makeStyles from '@mui/styles/makeStyles';
 import { FixedSizeList } from "react-window";
 
@@ -9,12 +9,22 @@ export default function LogLines(props) {
 
     const scrollTo = props.scrollTo;
 
+    const [maxLengthLine, setMaxLength] = useState(0)
+
     const listRef = React.createRef();
+
     useEffect(() => {
         if (scrollTo > -1) {
             listRef.current?.scrollToItem(scrollTo, "center");
         }
+
+
     }, [listRef, scrollTo]);
+
+    useEffect( () => {
+        let longest = Math.max(...(lines.map(el => el.length)));
+        setMaxLength(longest)
+    }, [props.lines])
 
     const classes = makeStyles(theme => ({
         log: {
@@ -28,12 +38,14 @@ export default function LogLines(props) {
             }
         },
         linewrap: {
+            width:  `${maxLengthLine}ch !important`,
             "&[data-matched=\"true\"]": {
                 "background-color": "rgba(255, 255, 0, .2)"
             }
         },
         line: {
             paddingLeft: theme.spacing(1),
+
             "&::before": {
                 content: "attr(data-linenumber)",
                 display: "inline-block",
@@ -123,15 +135,14 @@ export default function LogLines(props) {
             break;
         }
     }
-
     return (
-        <code className={classes.log}>
+       <code className={classes.log}>
             <pre className={classes.pre}>
-                <FixedSizeList 
+                <FixedSizeList
                     height={500}
                     itemCount={lineCount}
                     itemSize={20}
-                    style={{overflow: "scroll"}}
+                    style={{overflow: "scroll", width:"100%"}}
                     ref={listRef}
                 >
                     {Line}


### PR DESCRIPTION
I have tried to debug why isnt forcing to highlight the whole row after the scroll view, the solution I found was to force the max length for each one of the lines.

Apparently the wrapper from FixedSizeList force a width 100% which is the cause of the cutting off, I couldnt find where it was applied or to stop applying in, potentially impossible because is embedded in the core.

Looking for the longest string, saving the variable and applying via css, it fixes the issue.